### PR TITLE
Add unetp link and change default to unet

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -4,7 +4,8 @@
 
 * `cd back/`
 * Install dependencies with `pip install -r requirements.txt`
-* Download the bigger model [u2net.pth (173.6 MB)](https://drive.google.com/file/d/1ao1ovG1Qtx4b7EoskHXmi2E9rp5CHLcZ/view?usp=sharing)
+* Download the bigger model [u2net.pth (173.6 MB)](https://drive.google.com/file/d/1ao1ovG1Qtx4b7EoskHXmi2E9rp5CHLcZ/view?usp=sharing) - Default (Can be changed from app.py)
+* Download the smaller model [u2netp.pth (4.7 MB)](https://drive.google.com/file/d/1rbSTGKAE-MTxBYHd-51l2hMOQPT_7EPy/view?usp=sharing)
 
 
 ### Usage

--- a/back/app.py
+++ b/back/app.py
@@ -17,7 +17,7 @@ import detect
 app = Flask(__name__)
 CORS(app)
 
-net = detect.load_model(model_name="u2netp")
+net = detect.load_model(model_name="u2net")
 
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION
Hi William. Thank you for making this repo open source, helped a lot in my project. I saw that there's a minor mistake in the repo. The link given was of unet2 but the default was set to unet2p in the app.py file. This PR will fix it.


Cheers !